### PR TITLE
Updated Makefile to use MAKE command from parent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,18 @@
-nproc=$(shell python3 -c 'import multiprocessing; print( max(multiprocessing.cpu_count() - 1, 1))')
+#nproc=$(shell python3 -c 'import multiprocessing; print( max(multiprocessing.cpu_count() - 1, 1))')
 
 CXX := clang++-10
 CC := clang-10
 
 .PHONY: plugin.dbg.so
 plugin.dbg.so: build/Debug/Makefile
-	make -C build/Debug "-j$(nproc)" && \
+	${MAKE} -C build/Debug  && \
 	rm -f $@ && \
 	ln -s build/Debug/libplugin.so plugin.dbg.so && \
 	true
 
 .PHONY: plugin.opt.so
 plugin.opt.so: build/Release/Makefile
-	make -C build/Release "-j$(nproc)" && \
+	${MAKE} -C build/Release  && \
 	rm -f $@ && \
 	ln -s build/Release/libplugin.so plugin.opt.so && \
 	true


### PR DESCRIPTION
This gets rid of Kimera's makefile deciding its own nproc limit.